### PR TITLE
Updated: user login and intergration type mapping API's and used system message remote id instead of netsuite account id. (79-fix-netsuite-account-id-in-create-api-key-service)

### DIFF
--- a/screen/LoopNetsuiteConnector/OrganizationDetail.xml
+++ b/screen/LoopNetsuiteConnector/OrganizationDetail.xml
@@ -265,7 +265,7 @@ along with this software (see the LICENSE.md file). If not, see
                             <default-field><display/></default-field>
                         </field>
                         <field name="apiKey">
-                            <conditional-field condition="loginKeyMap.get(remoteId) == null">
+                            <conditional-field condition="loginKeyMap.get(systemMessageRemoteId) == null">
                                 <dynamic-dialog id="generateAPIKey" button-text="Generate API Key" transition="createUserLoginAPIKey" width="800"/>
                             </conditional-field>
                             <default-field>
@@ -330,7 +330,7 @@ along with this software (see the LICENSE.md file). If not, see
                                         </link>
                                     </box-toolbar>
                                     <box-body>
-                                        <form-list name="IntegrationMappingList" list="integrationTypeMappingMap.get(netsuiteRemote.remoteId)">
+                                        <form-list name="IntegrationMappingList" list="integrationTypeMappingMap.get(netsuiteRemote.systemMessageRemoteId)">
                                             <field name="userId"><default-field><hidden/></default-field></field>
                                             <field name="organizationPartyId"><default-field><hidden/></default-field></field>
                                             <field name="integrationMappingId">

--- a/service/co/hotwax/configuration/UserProfileServices.xml
+++ b/service/co/hotwax/configuration/UserProfileServices.xml
@@ -132,10 +132,9 @@
             <if condition="systemMessageRemote == null">
                 <return error="true" message="NetSuite Account not found for organization : ${organizationName} [${organizationPartyId}]"/>
             </if>
-            <set field="netSuiteRemoteId" from="systemMessageRemote.remoteId"/>
 
             <entity-find entity-name="moqui.security.UserAccount" list="userAccountList">
-                <econdition field-name="externalUserId" operator="equals" from="netSuiteRemoteId"/>
+                <econdition field-name="externalUserId" operator="equals" from="systemMessageRemoteId"/>
             </entity-find>
 
             <if condition="userAccountList">
@@ -156,7 +155,7 @@
 
             <!-- Create Integration User Account -->
             <service-call name="org.moqui.impl.UserServices.create#UserAccount"
-                          in-map="[username:netSuiteRemoteId + '_Integration', newPassword:password, newPasswordVerify:password, partyId:integrationPartyId, externalUserId:netSuiteRemoteId]"
+                          in-map="[username:systemMessageRemoteId + '_Integration', newPassword:password, newPasswordVerify:password, partyId:integrationPartyId, externalUserId:systemMessageRemoteId]"
                           out-map="userOut"/>
             <set field="integrationUserId" from="userOut.userId"/>
 
@@ -231,10 +230,9 @@
                 <entity-find-one entity-name="moqui.service.message.SystemMessageRemote" value-field="systemMessageRemote" cache="true">
                     <field-map field-name="systemMessageRemoteId" from="systemMessageRemoteId"/>
                 </entity-find-one>
-                <set field="netSuiteRemoteId" from="systemMessageRemote.remoteId"/>
 
                 <entity-find entity-name="moqui.security.UserAccount" list="userAccountList">
-                    <econdition field-name="externalUserId" operator="equals" from="netSuiteRemoteId"/>
+                    <econdition field-name="externalUserId" operator="equals" from="systemMessageRemoteId"/>
                 </entity-find>
 
                 <if condition="userAccountList">
@@ -247,7 +245,7 @@
 
                     <if condition="userLoginKeyList">
                         <script>
-                            loginKeyMap.put(netSuiteRemoteId, userLoginKeyList[0].loginKey)
+                            loginKeyMap.put(systemMessageRemoteId, userLoginKeyList[0].loginKey)
                         </script>
                     </if>
                 </if>
@@ -279,10 +277,6 @@
 
             <iterate list="partySystemMessageRemoteList" entry="partySystemMessageRemote">
                 <set field="systemMessageRemoteId" from="partySystemMessageRemote.systemMessageRemoteId"/>
-                <entity-find-one entity-name="moqui.service.message.SystemMessageRemote" value-field="systemMessageRemote">
-                    <field-map field-name="systemMessageRemoteId" from="systemMessageRemoteId"/>
-                </entity-find-one>
-                <set field="netSuiteRemoteId" from="systemMessageRemote.remoteId"/>
 
                 <entity-find entity-name="co.hotwax.netsuite.IntegrationTypeMapping"
                              list="intTypeMappingList">
@@ -302,8 +296,8 @@
                     </script>
                 </iterate>
                 <script>
-                    if (netSuiteRemoteId) {
-                        integrationTypeMappingMap.put(netSuiteRemoteId, tmpList)
+                    if (systemMessageRemoteId) {
+                        integrationTypeMappingMap.put(systemMessageRemoteId, tmpList)
                     }
                 </script>
             </iterate>


### PR DESCRIPTION
…